### PR TITLE
apple-sdk: rename as_sdk_path -> sdk_path

### DIFF
--- a/apple-sdk/src/lib.rs
+++ b/apple-sdk/src/lib.rs
@@ -934,12 +934,17 @@ pub trait AppleSdk: Sized + AsRef<Path> {
     }
 
     /// Obtain an [SdkPath] represent this SDK.
-    fn as_sdk_path(&self) -> SdkPath {
+    fn sdk_path(&self) -> SdkPath {
         SdkPath {
             path: self.path().to_path_buf(),
             platform: self.platform().clone(),
             version: self.version().cloned(),
         }
+    }
+
+    #[deprecated(since = "0.1.1", note = "plase use `sdk_path` instead")]
+    fn as_sdk_path(&self) -> SdkPath {
+        self.sdk_path()
     }
 
     /// Obtain the filesystem path to this SDK.

--- a/apple-sdk/src/search.rs
+++ b/apple-sdk/src/search.rs
@@ -561,7 +561,7 @@ impl SdkSearch {
                     self.filter_sdk(&sdk)?
                 } else {
                     if let Some(cb) = &self.progress_callback {
-                        cb(SdkSearchEvent::SdkFilterSkip(sdk.as_sdk_path()));
+                        cb(SdkSearchEvent::SdkFilterSkip(sdk.sdk_path()));
                     }
 
                     true
@@ -592,7 +592,7 @@ impl SdkSearch {
     /// This is exposed as a convenience method to allow custom implementations of
     /// SDK searching using the filtering logic on this type.
     pub fn filter_sdk<SDK: AppleSdk>(&self, sdk: &SDK) -> Result<bool, Error> {
-        let sdk_path = sdk.as_sdk_path();
+        let sdk_path = sdk.sdk_path();
 
         if let Some(wanted_platform) = &self.platform {
             if sdk.platform() != wanted_platform {


### PR DESCRIPTION
not to confuse to ad-hoc conversion conventions in API guidelines

https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv